### PR TITLE
Remove firstload / reload logic (PRC)

### DIFF
--- a/config-inifiles/lib/Config/IniFiles.pm
+++ b/config-inifiles/lib/Config/IniFiles.pm
@@ -387,7 +387,6 @@ sub new
         imported                => undef,
         v                       => {},
         cf                      => undef,
-        firstload               => 1,
         nomultiline             => 0,
         handle_trailing_comment => 0,
     }, $class;
@@ -1309,34 +1308,25 @@ sub ReadConfig
 
     if ( defined $self->{imported} )
     {
-        # Run up the import tree to the top, then reload coming
-        # back down, maintaining the imported file names and our
-        # file name.
-        # This is only needed on a reload though
-        $self->{imported}->ReadConfig() unless ( $self->{firstload} );
-
         foreach my $field (qw(sects parms group v sCMT pCMT EOT e))
         {
             $self->{$field} = _deepcopy( $self->{imported}->{$field} );
         }
-    }    # end if
+    }
 
     if ( $self->_no_filename )
     {
         return 1;
     }
 
-    # If this is a reload and we want warnings then send one to the STDERR log
-    unless ( $self->{firstload} || !$self->{reloadwarn} )
+    # If we want warnings, then send one to the STDERR log
+    if ( $self->{reloadwarn} )
     {
         my ( $ss, $mm, $hh, $DD, $MM, $YY ) = ( localtime(time) )[ 0 .. 5 ];
         printf STDERR
             "PID %d reloading config file %s at %d.%02d.%02d %02d:%02d:%02d\n",
             $$, $self->{cf}, $YY + 1900, $MM + 1, $DD, $hh, $mm, $ss;
     }
-
-    # Turn off. Future loads are reloads
-    $self->{firstload} = 0;
 
     # Get a filehandle, allowing almost any type of 'file' parameter
     my $fh = $self->_make_filehandle( $self->{cf} );
@@ -3262,7 +3252,6 @@ data structure.
 
   $iniconf->{cf} = "config_file_name"
           ->{startup_settings} = \%orginal_object_parameters
-          ->{firstload} = 0 OR 1
           ->{imported} = $object WHERE $object->isa("Config::IniFiles")
           ->{nocase} = 0
           ->{reloadwarn} = 0

--- a/config-inifiles/t/35reload-config-no-file.t
+++ b/config-inifiles/t/35reload-config-no-file.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+use Config::IniFiles;
+use Test::More;
+use File::Temp 'tempfile';
+
+my $config_nofile = Config::IniFiles->new( -allowempty => 1 );
+$config_nofile->newval( 'section', 'param', 1 );
+
+my ( $fh, $filename ) = tempfile;
+
+## Import config, set filename, read config, then read again
+my $config =
+    Config::IniFiles->new( -import => $config_nofile, -allowempty => 1 );
+
+ok( $config->val( 'section', 'param' ), 'Configuration is imported' );
+
+$config->SetFileName($filename);
+$config->ReadConfig;
+ok( $config->val( 'section', 'param' ), 'Configuration is still imported' );
+
+$config->ReadConfig;
+ok( $config->val( 'section', 'param' ), 'Configuration is still imported' );
+
+## Import config that has already been imported
+$config = Config::IniFiles->new(
+    -import     => $config_nofile,
+    -allowempty => 1,
+    -file       => $filename
+);
+
+ok( $config->val( 'section', 'param' ), 'Configuration is imported again' );
+
+$config_nofile = Config::IniFiles->new;
+$config_nofile->newval( 'section', 'param', 1 );
+
+## Import config and set filename in constructor, then read again
+$config = Config::IniFiles->new(
+    -import     => $config_nofile,
+    -allowempty => 1,
+    -file       => $filename
+);
+
+ok( $config->val( 'section', 'param' ), 'Configuration is imported' );
+
+$config->ReadConfig;
+ok( $config->val( 'section', 'param' ), 'Configuration is still imported' );
+
+## Import config that is written to file, but with parameters not written to file, then read again
+
+my ( $fh2, $filename2 ) = tempfile;
+my $config_file =
+    Config::IniFiles->new( -allowempty => 1, -file => $filename2 );
+$config_file->newval( 'section', 'param2', 1 );
+$config_file->RewriteConfig;
+$config_file->newval( 'section', 'param', 1 );
+
+$config = Config::IniFiles->new(
+    -import     => $config_file,
+    -allowempty => 1,
+    -file       => $filename
+);
+
+ok( $config->val( 'section', 'param' ), 'Configuration is imported' );
+
+$config->ReadConfig;
+ok( $config->val( 'section', 'param' ), 'Configuration is still imported' );
+
+done_testing;


### PR DESCRIPTION
As reported in RT [#104763](https://rt.cpan.org/Ticket/Display.html?id=104763), the `ReloadConfig` method could lead to unexpected behaviour when called on objects that had imported an object that had been created with no file, and had been assigned a filename during their lifetime.

A test file provided in that bug report is included in this patch.

This turned out to be a problem with the `firstload` / `reload` logic in `ReloadConfig`. Its role was apparently to support objects with multiple nested imports while avoiding unnecessary reloads. 

However, this appears to have been a feature that was either untested, or not behaving as expected, since removing it entirely still allows the test suite to pass, including the new test.

This closes RT [#104763](https://rt.cpan.org/Ticket/Display.html?id=104763).
