### PR TITLE
added feature -php_compat

### DIFF
--- a/config-inifiles/lib/Config/IniFiles.pm
+++ b/config-inifiles/lib/Config/IniFiles.pm
@@ -566,7 +566,7 @@ otherwise the values will be joined using \n.
 
 =cut
 
-sub _assimilate
+sub _caseify
 {
     my ( $self, @refs ) = @_;
 
@@ -612,7 +612,7 @@ sub val
         return;
     }
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     my $val_sect =
         defined( $self->{v}{$sect}{$parm} )
@@ -664,7 +664,7 @@ sub exists
 {
     my ( $self, $sect, $parm ) = @_;
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     return ( exists $self->{v}{$sect}{$parm} );
 }
@@ -688,7 +688,7 @@ sub push
     return undef if not defined $sect;
     return undef if not defined $parm;
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     return undef if ( !defined( $self->{v}{$sect}{$parm} ) );
 
@@ -728,7 +728,7 @@ sub setval
     return undef if not defined $sect;
     return undef if not defined $parm;
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     if ( defined( $self->{v}{$sect}{$parm} ) )
     {
@@ -768,7 +768,7 @@ sub newval
     return undef if not defined $sect;
     return undef if not defined $parm;
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     $self->AddSection($sect);
 
@@ -808,7 +808,7 @@ sub delval
     return undef if not defined $sect;
     return undef if not defined $parm;
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     $self->{parms}{$sect} = [ grep { $_ ne $parm } @{ $self->{parms}{$sect} } ];
     $self->_touch_parameter( $sect, $parm );
@@ -1080,7 +1080,7 @@ sub _ReadConfig_new_section
 {
     my ( $self, $sect ) = @_;
 
-    $self->_assimilate( undef, \$sect );
+    $self->_caseify( undef, \$sect );
 
     $self->_curr_sect($sect);
     $self->AddSection( $self->_curr_sect );
@@ -1232,7 +1232,7 @@ sub _ReadConfig_param_assignment
 {
     my ( $self, $fh, $line, $parm, $value_to_assign ) = @_;
 
-    $self->_assimilate( undef, \$parm, \$value_to_assign );
+    $self->_caseify( undef, \$parm, \$value_to_assign );
 
     $self->_curr_val($value_to_assign);
     $self->_curr_end_comment( undef() );
@@ -1457,7 +1457,7 @@ sub SectionExists
 
     return undef if not defined $sect;
 
-    $self->_assimilate( \$sect );
+    $self->_caseify( \$sect );
 
     return ( ( exists $self->{e}{$sect} ) ? 1 : 0 );
 }
@@ -1502,7 +1502,7 @@ sub AddSection
 
     return undef if not defined $sect;
 
-    $self->_assimilate( \$sect );
+    $self->_caseify( \$sect );
 
     if ( $self->SectionExists($sect) )
     {
@@ -1558,7 +1558,7 @@ sub DeleteSection
 
     return undef if not defined $sect;
 
-    $self->_assimilate( \$sect );
+    $self->_caseify( \$sect );
 
     # This is done the fast way, change if data structure changes!!
     delete $self->{v}{$sect};
@@ -1617,7 +1617,7 @@ sub CopySection
         return undef;
     }
 
-    $self->_assimilate( \$new_sect );
+    $self->_caseify( \$new_sect );
     $self->_AddSection_Helper($new_sect);
 
     # This is done the fast way, change if data structure changes!!
@@ -1662,7 +1662,7 @@ sub Parameters
 
     return undef if not defined $sect;
 
-    $self->_assimilate( \$sect );
+    $self->_caseify( \$sect );
 
     return @{ _aref_or_empty( $self->{parms}{$sect} ) };
 }
@@ -1796,7 +1796,7 @@ sub GroupMembers
 
     return undef if not defined $group;
 
-    $self->_assimilate( \$group );
+    $self->_caseify( \$group );
 
     return @{ _aref_or_empty( $self->{group}{$group} ) };
 }
@@ -2276,7 +2276,7 @@ sub SetSectionComment
         return undef;
     }
 
-    $self->_assimilate( \$sect );
+    $self->_caseify( \$sect );
 
     $self->_touch_section($sect);
 
@@ -2328,7 +2328,7 @@ sub GetSectionComment
 
     return undef if not defined $sect;
 
-    $self->_assimilate( \$sect );
+    $self->_caseify( \$sect );
 
     if ( !exists $self->{sCMT}{$sect} )
     {
@@ -2351,7 +2351,7 @@ sub DeleteSectionComment
 
     return undef if not defined $sect;
 
-    $self->_assimilate( \$sect );
+    $self->_caseify( \$sect );
     $self->_touch_section($sect);
 
     delete $self->{sCMT}{$sect};
@@ -2377,7 +2377,7 @@ sub SetParameterComment
         return undef;
     }
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     $self->_touch_parameter( $sect, $parm );
 
@@ -2421,7 +2421,7 @@ sub GetParameterComment
         return undef;
     }
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     if (
         not(   exists( $self->{pCMT}{$sect} )
@@ -2449,7 +2449,7 @@ sub DeleteParameterComment
         return undef;
     }
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     # If the parameter doesn't exist, our goal has already been achieved
     if (   exists( $self->{pCMT}{$sect} )
@@ -2477,7 +2477,7 @@ sub GetParameterEOT
         return undef;
     }
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     return $self->{EOT}{$sect}{$parm};
 }
@@ -2499,7 +2499,7 @@ sub SetParameterEOT
         return undef;
     }
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     $self->_touch_parameter( $sect, $parm );
 
@@ -2525,7 +2525,7 @@ sub DeleteParameterEOT
         return undef;
     }
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     $self->_touch_parameter( $sect, $parm );
     delete $self->{EOT}{$sect}{$parm};
@@ -2553,7 +2553,7 @@ sub SetParameterTrailingComment
         return undef;
     }
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     # confirm the parameter exist
     return undef if not exists $self->{v}{$sect}{$parm};
@@ -2582,7 +2582,7 @@ sub GetParameterTrailingComment
         return undef;
     }
 
-    $self->_assimilate( \$sect, \$parm );
+    $self->_caseify( \$sect, \$parm );
 
     # confirm the parameter exist
     return undef if not exists $self->{v}{$sect}{$parm};
@@ -2789,7 +2789,7 @@ sub FETCH
 
     $self->{_section_cache} ||= {};
 
-    $self->_assimilate( \$key );
+    $self->_caseify( \$key );
     return if ( !$self->{v}{$key} );
 
     return $self->{_section_cache}->{$key} if exists $self->{_section_cache}->{$key};
@@ -2814,7 +2814,7 @@ sub STORE
 
     return undef unless ref($ref) eq 'HASH';
 
-    $self->_assimilate( \$key );
+    $self->_caseify( \$key );
 
     $self->AddSection($key);
     $self->{v}{$key}       = {%$ref};

--- a/config-inifiles/t/36php-compat.t
+++ b/config-inifiles/t/36php-compat.t
@@ -1,0 +1,46 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 3;
+
+use Config::IniFiles;
+
+use lib "./t/lib";
+
+use Config::IniFiles::TestPaths;
+
+my $ini = Config::IniFiles->new( -file => t_file('php-compat.ini'), -php_compat => 1 ) or die($!);
+#my $ini = Config::IniFiles->new( -file => t_file('php-compat.ini'), -php_compat => 0 ) or die($!);
+my $members;
+
+# Test 1
+# strings enclosed with " are processed as double quoted string
+
+# TEST
+is_deeply(
+    [ scalar ( $ini->val("group1","val1") ) ],
+    [ q{str"ing} ],
+    "value with double-quotes in php_compat",
+);
+
+# Test 2
+# strings enclosed with ' are processed as single quoted string
+
+# TEST
+is_deeply(
+    [ $ini->val("group1","val2") ],
+    [ q{string} ],
+    "value with single-quotes in php_compat",
+);
+
+# Test 3
+# ignore [] in val-Names
+
+# TEST
+is_deeply(
+    [ $ini->val("group2","val1") ],
+    [ 1, 2 ],
+    "value with php array key in php_compat",
+);

--- a/config-inifiles/t/36php-compat.t
+++ b/config-inifiles/t/36php-compat.t
@@ -11,18 +11,18 @@ use lib "./t/lib";
 
 use Config::IniFiles::TestPaths;
 
-my $ini = Config::IniFiles->new( -file => t_file('php-compat.ini'), -php_compat => 1 ) or die($!);
-#my $ini = Config::IniFiles->new( -file => t_file('php-compat.ini'), -php_compat => 0 ) or die($!);
-my $members;
+my $ini = Config::IniFiles->new(
+    -file       => t_file('php-compat.ini'),
+    -php_compat => 1
+) or die($!);
 
 # Test 1
 # strings enclosed with " are processed as double quoted string
 
 # TEST
 is_deeply(
-    [ scalar ( $ini->val("group1","val1") ) ],
-    [ q{str"ing} ],
-    "value with double-quotes in php_compat",
+    [ scalar( $ini->val( "group1", "val1" ) ) ],
+    [q{str"ing}], "value with double-quotes in php_compat",
 );
 
 # Test 2
@@ -30,9 +30,8 @@ is_deeply(
 
 # TEST
 is_deeply(
-    [ $ini->val("group1","val2") ],
-    [ q{string} ],
-    "value with single-quotes in php_compat",
+    [ $ini->val( "group1", "val2" ) ],
+    [q{string}], "value with single-quotes in php_compat",
 );
 
 # Test 3
@@ -40,7 +39,7 @@ is_deeply(
 
 # TEST
 is_deeply(
-    [ $ini->val("group2","val1") ],
+    [ $ini->val( "group2", "val1" ) ],
     [ 1, 2 ],
     "value with php array key in php_compat",
 );

--- a/config-inifiles/t/php-compat.ini
+++ b/config-inifiles/t/php-compat.ini
@@ -1,0 +1,7 @@
+[group1]
+val1="str\"in""g"
+val2='strin''g'
+
+[group2]
+val1[]=1
+val1[]=2

--- a/config-inifiles/t/php-compat.php
+++ b/config-inifiles/t/php-compat.php
@@ -1,0 +1,2 @@
+<?php
+print_r(parse_ini_file('php-compat.ini', true));


### PR DESCRIPTION
* new feature php_compat
 * rudimentary support for PHP parse_ini_file() syntax
  * one configfile for Perl and PHP scripts is with -php_compat now possible
  * rename _casify to _assimilate (bad naming)